### PR TITLE
Changes to preserve original order file when running

### DIFF
--- a/idflakies-maven-plugin/src/main/java/edu/illinois/cs/dt/tools/plugin/IncDetectorMojo.java
+++ b/idflakies-maven-plugin/src/main/java/edu/illinois/cs/dt/tools/plugin/IncDetectorMojo.java
@@ -412,6 +412,7 @@ public class IncDetectorMojo extends DetectorMojo {
     protected List<String> getTests(
             final MavenProject project,
             TestFramework testFramework) throws IOException {
+        // NOTE: Do we need to re-compute original order, or expect developer to provide already?
         List<String> tests = getOriginalOrder(project, testFramework, true);
         List<String> affectedTests = new ArrayList<>();
 
@@ -428,6 +429,7 @@ public class IncDetectorMojo extends DetectorMojo {
     private List<String> getTestClasses(
             final MavenProject project,
             TestFramework testFramework) throws IOException {
+        // NOTE: Do we need to re-compute original order, or expect developer to provide already?
         List<String> tests = getOriginalOrder(project, testFramework, true);
 
         String delimiter = testFramework.getDelimiter();

--- a/scripts/original-order-files/dubbo-rpc@dubbo-rpc-dubbo
+++ b/scripts/original-order-files/dubbo-rpc@dubbo-rpc-dubbo
@@ -17,14 +17,6 @@ org.apache.dubbo.rpc.protocol.dubbo.ImplicitCallBackTest.test_Ex_OnReturn
 org.apache.dubbo.rpc.protocol.dubbo.ImplicitCallBackTest.test_CloseCallback
 org.apache.dubbo.rpc.protocol.dubbo.ImplicitCallBackTest.test_Async_Future_Multi
 org.apache.dubbo.rpc.protocol.dubbo.ImplicitCallBackTest.test_Sync_NoFuture
-org.apache.dubbo.rpc.protocol.dubbo.support.EnumBak.testGenricCustomArg
-org.apache.dubbo.rpc.protocol.dubbo.support.EnumBak.testNormalEnum
-org.apache.dubbo.rpc.protocol.dubbo.support.EnumBak.testGenricEnumCompat
-org.apache.dubbo.rpc.protocol.dubbo.support.EnumBak.testGenericEnum
-org.apache.dubbo.rpc.protocol.dubbo.support.EnumBak.testExportService
-org.apache.dubbo.rpc.protocol.dubbo.support.EnumBak.testNormal
-org.apache.dubbo.rpc.protocol.dubbo.support.EnumBak.testGenericExport
-org.apache.dubbo.rpc.protocol.dubbo.support.EnumBak.testEnumCompat
 org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest.testSticky1
 org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest.testSticky2
 org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest.testSticky3

--- a/scripts/test-many-projects.sh
+++ b/scripts/test-many-projects.sh
@@ -168,7 +168,6 @@ function checkFlakyTests() {
 
             #5. Using a preset original order, run the default test for each
             setOriginalOrder ${starr[4]} ${MODULE}
-            exit
             mvn ${mvnCommand} -Ddetector.detector_type=random-class-method -Ddt.randomize.rounds=5 -Ddt.detector.original_order.all_must_pass=false -Ddt.detector.roundsemantics.total=true ${MVNOPTIONS} ${PL} -B
             if [[ $? != 0 ]]; then
                 echo "${URL} iDFlakies was not successful. %%%%%"

--- a/scripts/test-many-projects.sh
+++ b/scripts/test-many-projects.sh
@@ -46,7 +46,7 @@ function setOriginalOrder() {        #Copies the original order of tests we want
         cd ${currModule}
     fi
     mkdir .dtfixingtools
-    fileName=${currModule//[/]/@}
+    fileName=${currModule//[\/]/@}
     if [[ ${currModule} == "" ]]; then
         cp ${scriptDir}/original-order-files/${projName} .dtfixingtools/original-order
     else
@@ -168,6 +168,7 @@ function checkFlakyTests() {
 
             #5. Using a preset original order, run the default test for each
             setOriginalOrder ${starr[4]} ${MODULE}
+            exit
             mvn ${mvnCommand} -Ddetector.detector_type=random-class-method -Ddt.randomize.rounds=5 -Ddt.detector.original_order.all_must_pass=false -Ddt.detector.roundsemantics.total=true ${MVNOPTIONS} ${PL} -B
             if [[ $? != 0 ]]; then
                 echo "${URL} iDFlakies was not successful. %%%%%"


### PR DESCRIPTION
The main goal of this pull request is to change the detector logic to not overwrite any existing original order file. The original order file is overwritten all the time, mainly due to the needs of the new IncIDFlakies logic that has to grab any new original order after some changes as to check if there are new tests. However, that logic ruins the tests we run during CI because the original order files we copy in for more deterministic builds get ignored.

There are some additional changes to fix some logic in the testing scripts, as well as modify some original order file for the incubator-dubbo project we use for testing, as to remove some tests that should actually not be run.

With these changes, the the CI build that was failing from before due to the failing test scripts should now pass.