### PR TITLE
Update starts plugin version

### DIFF
--- a/idflakies-maven-plugin/pom.xml
+++ b/idflakies-maven-plugin/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>edu.illinois</groupId>
             <artifactId>starts-maven-plugin</artifactId>
-            <version>1.3</version>
+            <version>1.4</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The previous STARTS plugin version prevents us from using Java versions above Java 8. The new version of STARTS allows us to use higher versions of Java.