### PR TITLE
Sort original order tests from locateTests

### DIFF
--- a/idflakies-maven-plugin/src/main/java/edu/illinois/cs/dt/tools/plugin/DetectorMojo.java
+++ b/idflakies-maven-plugin/src/main/java/edu/illinois/cs/dt/tools/plugin/DetectorMojo.java
@@ -38,6 +38,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -305,15 +306,17 @@ public class DetectorMojo extends AbstractIDFlakiesMojo {
         if (!locateTestList.containsKey(id)) {
             Logger.getGlobal().log(Level.INFO, "Locating tests...");
             try {
-		        locateTestList.put(id, OperationTime.runOperation(() -> {
-                    return new ArrayList<String>(JavaConverters.bufferAsJavaList(TestLocator.tests(project, testFramework).toBuffer()));
+                locateTestList.put(id, OperationTime.runOperation(() -> {
+                    List<String> tests = new ArrayList<>(JavaConverters.bufferAsJavaList(TestLocator.tests(project, testFramework).toBuffer()));
+                    Collections.sort(tests);
+                    return tests;
                 }, (tests, time) -> {
                     Logger.getGlobal().log(Level.INFO, "Located " + tests.size() + " tests. Time taken: " + time.elapsedSeconds() + " seconds");
                     return tests;
                 }));
-	        } catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
-	        }
+            }
         }
         return locateTestList.get(id);
     }


### PR DESCRIPTION
This pull request implements sorting of the tests obtained from parsing the test code from the underlying project, when the original order is not provided or it is not configured to parse out the tests from surefire reports and the output of a previous test run. This pull request also addresses some tab/space formatting issues in the surrounding code. This pull request aims to address part of the concerns reported in Issue #51 

Note that if you want a deterministic experience with iDFlakies and how it orders tests starting from this original order, it is still recommended to provide the original-order file (iDFlakies will use the order of tests in this file), or to provide the `mvn-test.log` + surefire reports from a previous test run so it can parse out which order was used then.