### PR TITLE
Docker Framework Plugin Resolution Fix

### DIFF
--- a/scripts/docker/run_project.sh
+++ b/scripts/docker/run_project.sh
@@ -22,7 +22,7 @@ rounds=$2
 timeout=$3
 
 iDFlakiesArtifactID="idflakies-maven-plugin"
-iDFlakiesVersion=2.0.0-SNAPSHOT
+iDFlakiesVersion=2.0.1-SNAPSHOT
 
 # Setup prolog stuff
 cd "/home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/"


### PR DESCRIPTION
Fixed docker looking for and older version of the maven plugin and being unable to resolve it by updating the reference to the latest version.
