### PR TITLE
Updating workflows to use v4 of upload action

### DIFF
--- a/.github/workflows/test-ifixflakies-fixer.yml
+++ b/.github/workflows/test-ifixflakies-fixer.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-ifixflakies-fixer_ARTIFACT_1
          path: scripts/testing-script-results/ARTIFACTS

--- a/.github/workflows/test-ifixflakies-minimizer.yml
+++ b/.github/workflows/test-ifixflakies-minimizer.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-ifixflakies-minimizer_ARTIFACT_1
          path: scripts/testing-script-results/ARTIFACTS

--- a/.github/workflows/test-many-configs-legacy.yml
+++ b/.github/workflows/test-many-configs-legacy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-configs_ARTIFACT
          path: scripts/MC-script-results/ARTIFACTS

--- a/.github/workflows/test-many-configs-maven-plugin.yml
+++ b/.github/workflows/test-many-configs-maven-plugin.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-configs_ARTIFACT
          path: scripts/MC-script-results/ARTIFACTS

--- a/.github/workflows/test-many-projects-legacy.yml
+++ b/.github/workflows/test-many-projects-legacy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-projects_ARTIFACT_1
          path: scripts/testing-script-results/ARTIFACTS
@@ -55,7 +55,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-projects_ARTIFACT_2
          path: scripts/testing-script-results/ARTIFACTS
@@ -83,7 +83,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-projects_ARTIFACT_3
          path: scripts/testing-script-results/ARTIFACTS
@@ -111,7 +111,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-projects_ARTIFACT_4
          path: scripts/testing-script-results/ARTIFACTS

--- a/.github/workflows/test-many-projects-maven-plugin.yml
+++ b/.github/workflows/test-many-projects-maven-plugin.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-projects_ARTIFACT_1
          path: scripts/testing-script-results/ARTIFACTS
@@ -55,7 +55,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-projects_ARTIFACT_2
          path: scripts/testing-script-results/ARTIFACTS
@@ -83,7 +83,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-projects_ARTIFACT_3
          path: scripts/testing-script-results/ARTIFACTS
@@ -111,7 +111,7 @@ jobs:
 
       - name: Save all relevant files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
          name: test-many-projects_ARTIFACT_4
          path: scripts/testing-script-results/ARTIFACTS


### PR DESCRIPTION
GitHub Actions deprecated older versions of the upload action and now they cannot be used. We need to update to v4 so the workflows still can run.